### PR TITLE
Fix deprecation warning in newer versions of rspec

### DIFF
--- a/lib/rspec_hpricot_matchers/have_tag.rb
+++ b/lib/rspec_hpricot_matchers/have_tag.rb
@@ -43,6 +43,10 @@ module RspecHpricotMatchers
       explanation = @actual_count ? "but found #{@actual_count}" : "but did"
       "expected\n#{@hdoc.to_s}\nnot to have #{failure_count_phrase} #{failure_selector_phrase}, #{explanation}"
     end
+    
+    def failure_message_when_negated
+      negative_failure_message
+    end
 
     private
       def hdoc_for(input)


### PR DESCRIPTION
Fixes deprecation message for newer versions of rspec

```
RspecHpricotMatchers::HaveTag implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
(Used from /Users/weston/html/open_source/rodf/spec/cell_spec.rb:11:in `block (2 levels) in <top (required)>')
```